### PR TITLE
override create_or_update to include class-specific fields when using get_id to find existing objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,8 @@ zbx.graphs.create(
   :show_triggers => "0",
   :name => "graph",
   :width => "900",
-  :height => "200"
+  :height => "200",
+  :hostid => zbx.templates.get_id(:host => "template")
 )
 ```
 
@@ -212,7 +213,8 @@ zbx.graphs.create_or_update(
   :show_triggers => "1",
   :name => graph,
   :width => "900",
-  :height => "200"
+  :height => "200",
+  :hostid => zbx.templates.get_id(:host => "template")
 )
 ```
 ### Get ids by host ###
@@ -257,7 +259,7 @@ zbx.triggers.create(
   :comments => "Bla-bla is faulty (disaster)",
   :priority => 5,
   :status     => 0,
-  :templateid => 0,
+  :hostid => zbx.templates.get_id(:host => "template"),
   :type => 0,
   :tags => [
     {

--- a/lib/zabbixapi/classes/applications.rb
+++ b/lib/zabbixapi/classes/applications.rb
@@ -47,5 +47,10 @@ class ZabbixApi
       applicationid
     end
 
+    def create_or_update(data)
+      applicationid = get_id(:name => data[:name], :hostid => data[:hostid])
+      applicationid ? update(data.merge(:applicationid => applicationid)) : create(data)
+    end
+
   end
 end

--- a/lib/zabbixapi/classes/applications.rb
+++ b/lib/zabbixapi/classes/applications.rb
@@ -1,36 +1,7 @@
 class ZabbixApi
-  class Applications
+  class Applications < Basic
 
     API_PARAMETERS = %w(applicationids groupids hostids inherited itemids templated templateids selectItems)
-
-    def initialize(client)
-      @client = client
-    end
-
-    def create(data)
-      result = @client.api_request(:method => "application.create", :params => [data])
-      result.empty? ? nil : result['applicationids'][0].to_i
-    end
-
-    def add(data)
-      create(data)
-    end
-
-    def delete(data)
-      result = @client.api_request(:method => "application.delete", :params => [data])
-      result.empty? ? nil : result['applicationids'][0].to_i
-    end
-
-    def get_or_create(data)
-      unless (appid = get_id(data))
-        appid = create(data)
-      end
-      appid
-    end
-
-    def destroy(data)
-      delete(data)
-    end
 
     def get_full_data(data)
       filter_params = {}

--- a/lib/zabbixapi/classes/applications.rb
+++ b/lib/zabbixapi/classes/applications.rb
@@ -3,6 +3,14 @@ class ZabbixApi
 
     API_PARAMETERS = %w(applicationids groupids hostids inherited itemids templated templateids selectItems)
 
+    def method_name
+      "application"
+    end
+
+    def indentify
+      "name"
+    end
+
     def get_full_data(data)
       filter_params = {}
       request_data = data.dup # Duplicate data, as we modify it. Otherwise methods that use data after calling get_full_data (such as get_id) will fail.

--- a/lib/zabbixapi/classes/httptests.rb
+++ b/lib/zabbixapi/classes/httptests.rb
@@ -18,7 +18,7 @@ class ZabbixApi
     end
 
     def create_or_update(data)
-      httptestid = get_id(:name => data[:name])
+      httptestid = get_id(:name => data[:name], :hostid => data[:hostid])
       httptestid ? update(data.merge(:httptestid => httptestid)) : create(data)
     end
   end

--- a/lib/zabbixapi/classes/items.rb
+++ b/lib/zabbixapi/classes/items.rb
@@ -45,5 +45,11 @@ class ZabbixApi
         :ipmi_sensor => ''
       }
     end
+
+    def create_or_update(data)
+      itemid = get_id(:name => data[:name], :hostid => data[:hostid])
+      itemid ? update(data.merge(:itemid => itemid)) : create(data)
+    end
+
   end
 end

--- a/lib/zabbixapi/classes/triggers.rb
+++ b/lib/zabbixapi/classes/triggers.rb
@@ -59,5 +59,10 @@ class ZabbixApi
 
     end
 
+    def create_or_update(data)
+      triggerid = get_id(:description => data[:description], :hostid => data[:hostid])
+      triggerid ? update(data.merge(:triggerid => triggerid)) : create(data)
+    end
+
   end
 end

--- a/spec/application.rb
+++ b/spec/application.rb
@@ -65,6 +65,15 @@ describe 'application' do
       end
     end
 
+    describe 'create_or_update' do
+      it "should return id of updated application" do
+        expect(zbx.applications.create_or_update(
+          :name => @application,
+          :hostid => @templateid
+        )).to eq @applicationid
+      end
+    end
+
     describe "delete" do
       it "should return id" do
         expect(zbx.applications.delete(@applicationid)).to eq @applicationid

--- a/spec/trigger.rb
+++ b/spec/trigger.rb
@@ -85,6 +85,15 @@ describe "trigger" do
       end
     end
 
+    describe 'create_or_update' do
+      it "should return id of updated trigger" do
+        expect(zbx.triggers.create_or_update(
+          :description => @trigger,
+          :hostid => @templateid
+        )).to eq @triggerid
+      end
+    end
+
     describe "delete" do
       it "should return id" do
         expect(zbx.triggers.delete( @triggerid )).to eq @triggerid


### PR DESCRIPTION
Did a once over of the zabbixapi classes and added create_or_update overrides for the ones that need additional fields for get_id queries against the API.

This is needed to support things like templated items, which are copied to all hosts linked to the template. The current create_or_update calls may pull one of the item copies instead because they are not specific enough with get_id.